### PR TITLE
Update requirements to support django 4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     license="Copyright © 2011-2024, DirectEmployers Association",
     packages=find_packages(exclude=["tests*"]),
     python_requires=">=3.11",
-    install_requires=["django>=4.2"],
+    install_requires=["django==4.2.*"],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import find_packages, setup
 
 setup(
     name="django-middleware",
-    version="1.0.0",
+    version="4.2",
     description="Reusable Django utilities for DE apps.",
-    url="https://github.com/DirectEmployers/django-utils",
-    license="Copyright © 2011-2022, DirectEmployers Association",
+    url="https://github.com/DirectEmployers/django-middleware",
+    license="Copyright © 2011-2024, DirectEmployers Association",
     packages=find_packages(exclude=["tests*"]),
-    python_requires=">=3.8",
-    install_requires=["django==3.2.*"],
+    python_requires=">=3.11",
+    install_requires=["django>=4.2"],
 )


### PR DESCRIPTION
- Bump package version (mirroring minimum Django version)
- Fix package repo URL
- Update minimum Python version to 3.11
- Pin Django version to 4.2.x
